### PR TITLE
chore: Add support for Max Token in Chat Completion

### DIFF
--- a/Sources/OpenAISwift/Models/ChatMessage.swift
+++ b/Sources/OpenAISwift/Models/ChatMessage.swift
@@ -24,4 +24,12 @@ public struct ChatMessage: Codable {
 public struct ChatConversation: Encodable {
     let messages: [ChatMessage]
     let model: String
+    let maxTokens: Int
+
+    enum CodingKeys: String, CodingKey {
+        case messages
+        case model
+        case maxTokens = "max_tokens"
+    }
+
 }

--- a/Sources/OpenAISwift/Models/ChatMessage.swift
+++ b/Sources/OpenAISwift/Models/ChatMessage.swift
@@ -24,7 +24,7 @@ public struct ChatMessage: Codable {
 public struct ChatConversation: Encodable {
     let messages: [ChatMessage]
     let model: String
-    let maxTokens: Int
+    let maxTokens: Int?
 
     enum CodingKeys: String, CodingKey {
         case messages

--- a/Sources/OpenAISwift/OpenAISwift.swift
+++ b/Sources/OpenAISwift/OpenAISwift.swift
@@ -75,7 +75,7 @@ extension OpenAISwift {
     ///   - messages: Array of `ChatMessages`
     ///   - model: The Model to use, the only support model is `gpt-3.5-turbo`
     ///   - completionHandler: Returns an OpenAI Data Model
-    public func sendChat(with messages: [ChatMessage], model: OpenAIModelType = .chat(.chatgpt), maxTokens: Int = 4096, completionHandler: @escaping (Result<OpenAI<MessageResult>, OpenAIError>) -> Void) {
+    public func sendChat(with messages: [ChatMessage], model: OpenAIModelType = .chat(.chatgpt), maxTokens: Int? = nil, completionHandler: @escaping (Result<OpenAI<MessageResult>, OpenAIError>) -> Void) {
         let endpoint = Endpoint.chat
         let body = ChatConversation(messages: messages, model: model.modelName, maxTokens: maxTokens)
         let request = prepareRequest(endpoint, body: body)
@@ -170,7 +170,7 @@ extension OpenAISwift {
     ///   - completionHandler: Returns an OpenAI Data Model
     @available(swift 5.5)
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
-    public func sendChat(with messages: [ChatMessage], model: OpenAIModelType = .chat(.chatgpt), maxTokens: Int = 4096) async throws -> OpenAI<MessageResult> {
+    public func sendChat(with messages: [ChatMessage], model: OpenAIModelType = .chat(.chatgpt), maxTokens: Int? = nil) async throws -> OpenAI<MessageResult> {
         return try await withCheckedThrowingContinuation { continuation in
             sendChat(with: messages, model: model, maxTokens: maxTokens) { result in
                 continuation.resume(with: result)

--- a/Sources/OpenAISwift/OpenAISwift.swift
+++ b/Sources/OpenAISwift/OpenAISwift.swift
@@ -75,9 +75,9 @@ extension OpenAISwift {
     ///   - messages: Array of `ChatMessages`
     ///   - model: The Model to use, the only support model is `gpt-3.5-turbo`
     ///   - completionHandler: Returns an OpenAI Data Model
-    public func sendChat(with messages: [ChatMessage], model: OpenAIModelType = .chat(.chatgpt), completionHandler: @escaping (Result<OpenAI<MessageResult>, OpenAIError>) -> Void) {
+    public func sendChat(with messages: [ChatMessage], model: OpenAIModelType = .chat(.chatgpt), maxTokens: Int = 4096, completionHandler: @escaping (Result<OpenAI<MessageResult>, OpenAIError>) -> Void) {
         let endpoint = Endpoint.chat
-        let body = ChatConversation(messages: messages, model: model.modelName)
+        let body = ChatConversation(messages: messages, model: model.modelName, maxTokens: maxTokens)
         let request = prepareRequest(endpoint, body: body)
         
         makeRequest(request: request) { result in
@@ -170,9 +170,9 @@ extension OpenAISwift {
     ///   - completionHandler: Returns an OpenAI Data Model
     @available(swift 5.5)
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
-    public func sendChat(with messages: [ChatMessage], model: OpenAIModelType = .chat(.chatgpt)) async throws -> OpenAI<MessageResult> {
+    public func sendChat(with messages: [ChatMessage], model: OpenAIModelType = .chat(.chatgpt), maxTokens: Int = 4096) async throws -> OpenAI<MessageResult> {
         return try await withCheckedThrowingContinuation { continuation in
-            sendChat(with: messages, model: model) { result in
+            sendChat(with: messages, model: model, maxTokens: maxTokens) { result in
                 continuation.resume(with: result)
             }
         }


### PR DESCRIPTION
Add support for Max Token in Chat Completion API

This pull request adds support for Max Token in the Chat Completion API. With this change, users can now specify the maximum number of tokens that can be generated.

Please review and merge. Thanks!